### PR TITLE
Updated to 2.0.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,20 @@
 {
   "name": "angular-add-to-home-screen",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/austinpray/angular-add-to-home-screen",
   "authors": [
     "Austin Pray <austin@austinpray.com>"
   ],
   "description": "An AngularJS directive to display an \"add to homescreen\" dialog for iOS 7 and iOS 6",
-  "main": "dist/angular-add-to-home-screen.js",
+  "license": "MIT",
+  "main": [
+    "dist/angular-add-to-home-screen.js",
+    "dist/aaths.css"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/austinpray/angular-add-to-home-screen.git"
+  },
   "keywords": [
     "ios",
     "add",
@@ -20,7 +28,9 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "example.css",
+    "example.html"
   ],
   "dependencies": {
     "angular": "1.2.x - 1.3.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-add-to-home-screen",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "An AngularJS directive to display an \"add to homescreen\" dialog for iOS 7 and iOS 6",
   "main": "dist/angular-add-to-home-screen.js",
   "directories": {
@@ -21,7 +21,7 @@
     "bookmark",
     "android"
   ],
-  "author": "Austin Pray",
+  "author": "Austin Pray <austin@austinpray.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/austinpray/angular-add-to-home-screen/issues"


### PR DESCRIPTION
As requested in #12.

Also, never really knew this but `version` isn't used by `bower` yet, as described in their [spec](https://github.com/bower/bower.json-spec#version), but it's fine to leave it in I guess.
### Includes:
- adds example to ignore
- adds email for author in package.json
- adds repository param to bower
- fixes main in bower
- adds license to bower
